### PR TITLE
[dashboard] Add `idle` query param to CPU profile endpoints

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -798,10 +798,7 @@ python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
 --------------------
 python/ray/dashboard/modules/reporter/profile_manager.py
     DOC111: Method `CpuProfilingManager.trace_dump`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
-    DOC101: Method `CpuProfilingManager.cpu_profile`: Docstring contains fewer arguments than in function signature.
-    DOC107: Method `CpuProfilingManager.cpu_profile`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
     DOC111: Method `CpuProfilingManager.cpu_profile`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
-    DOC103: Method `CpuProfilingManager.cpu_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [format: ].
     DOC101: Method `MemoryProfilingManager.get_profile_result`: Docstring contains fewer arguments than in function signature.
     DOC111: Method `MemoryProfilingManager.get_profile_result`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
     DOC103: Method `MemoryProfilingManager.get_profile_result`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [profiler_filename: str].
@@ -820,7 +817,7 @@ python/ray/dashboard/modules/reporter/reporter_head.py
     DOC103: Method `ReportHead.get_traceback`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request]. Arguments in the docstring but not in the function signature: [ip or node_id: , pid: ].
     DOC201: Method `ReportHead.get_traceback` does not have a return section in docstring
     DOC102: Method `ReportHead.cpu_profile`: Docstring contains more arguments than in function signature.
-    DOC103: Method `ReportHead.cpu_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request]. Arguments in the docstring but not in the function signature: [duration: , format: , ip or node_id: , native: , pid: ].
+    DOC103: Method `ReportHead.cpu_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request]. Arguments in the docstring but not in the function signature: [duration: , format: , idle: , ip or node_id: , native: , pid: ].
     DOC201: Method `ReportHead.cpu_profile` does not have a return section in docstring
     DOC101: Method `ReportHead.memory_profile`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `ReportHead.memory_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request].

--- a/python/ray/dashboard/modules/reporter/profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/profile_manager.py
@@ -119,19 +119,26 @@ class CpuProfilingManager:
             return True, decode(stdout)
 
     async def cpu_profile(
-        self, pid: int, format="flamegraph", duration: float = 5, native: bool = False
+        self,
+        pid: int,
+        format: str = "flamegraph",
+        duration: float = 5,
+        native: bool = False,
+        idle: bool = False,
     ) -> (bool, str):
         """
         Perform CPU profiling on a specified process.
 
         Args:
             pid: The process ID (PID) of the target process to be profiled.
-                format (str, optional): The format of the CPU profile output.
+            format (str, optional): The format of the CPU profile output.
                 Default is "flamegraph".
             duration (float, optional): The duration of the profiling
                 session in seconds. Default is 5 seconds.
             native (bool, optional): If True, includes native (C/C++) stack frames.
                 Default is False.
+            idle (bool, optional): If True, includes stack traces for idle
+                threads in the output. Default is False.
 
         Returns:
             Tuple[bool, str]: A tuple containing a boolean indicating the success
@@ -170,6 +177,8 @@ class CpuProfilingManager:
         ]
         if sys.platform == "linux" and native:
             cmd.append("--native")
+        if idle:
+            cmd.append("--idle")
         if await _can_passwordless_sudo():
             cmd = ["sudo", "-n"] + cmd
         process = await asyncio.create_subprocess_exec(

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -562,9 +562,10 @@ class ReporterAgent(
         duration = request.duration
         format = request.format
         native = request.native
+        idle = request.idle
         p = CpuProfilingManager(self._log_dir)
         success, output = await p.cpu_profile(
-            pid, format=format, duration=duration, native=native
+            pid, format=format, duration=duration, native=native, idle=idle
         )
         return reporter_pb2.CpuProfilingReply(output=output, success=success)
 

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -371,6 +371,8 @@ class ReportHead(SubprocessModule):
 
         # Default not using `--native` for profiling
         native = req.query.get("native", False) == "1"
+        # Default not using `--idle` for profiling
+        idle = req.query.get("idle", False) == "1"
         addrs = await self._get_stub_address_by_node_id(NodeID.from_hex(node_id_hex))
         if not addrs:
             raise aiohttp.web.HTTPInternalServerError(
@@ -387,12 +389,12 @@ class ReportHead(SubprocessModule):
             raise aiohttp.web.HTTPInternalServerError(text=str(e))
 
         logger.info(
-            f"Sending CPU profiling request to {build_address(ip, grpc_port)}, pid {pid}, for {task_id} with native={native}"
+            f"Sending CPU profiling request to {build_address(ip, grpc_port)}, pid {pid}, for {task_id} with native={native}, idle={idle}"
         )
 
         reply = await reporter_stub.CpuProfiling(
             reporter_pb2.CpuProfilingRequest(
-                pid=pid, duration=duration_s, format=format, native=native
+                pid=pid, duration=duration_s, format=format, native=native, idle=idle
             )
         )
 
@@ -493,6 +495,7 @@ class ReportHead(SubprocessModule):
             duration: Optional. Duration in seconds for profiling (default: 5, max: 60).
             format: Optional. Output format (default: "flamegraph").
             native: Optional. Whether to use native profiling (default: false).
+            idle: Optional. Whether to include idle threads in the output (default: false).
 
         Raises:
             ValueError: If pid is not provided.
@@ -536,12 +539,14 @@ class ReportHead(SubprocessModule):
 
         # Default not using `--native` for profiling
         native = req.query.get("native", False) == "1"
+        # Default not using `--idle` for profiling
+        idle = req.query.get("idle", False) == "1"
         logger.info(
-            f"Sending CPU profiling request to {build_address(ip, grpc_port)}, pid {pid}, with native={native}"
+            f"Sending CPU profiling request to {build_address(ip, grpc_port)}, pid {pid}, with native={native}, idle={idle}"
         )
         reply = await reporter_stub.CpuProfiling(
             reporter_pb2.CpuProfilingRequest(
-                pid=pid, duration=duration_s, format=format, native=native
+                pid=pid, duration=duration_s, format=format, native=native, idle=idle
             )
         )
         if reply.success:

--- a/python/ray/tests/test_dashboard_profiler.py
+++ b/python/ray/tests/test_dashboard_profiler.py
@@ -31,8 +31,9 @@ def enable_profiling():
     reason="Fails on OSX: https://github.com/ray-project/ray/issues/30114",
 )
 @pytest.mark.parametrize("native", ["0", "1"])
+@pytest.mark.parametrize("idle", ["0", "1"])
 @pytest.mark.parametrize("node_info", ["node_id", "ip"])
-def test_profiler_endpoints(ray_start_with_dashboard, native, node_info):
+def test_profiler_endpoints(ray_start_with_dashboard, native, idle, node_info):
     if native == "1" and sys.platform == "linux":
         pytest.skip(
             "py-spy --native 'failed to get os threadid' "
@@ -98,7 +99,8 @@ def test_profiler_endpoints(ray_start_with_dashboard, native, node_info):
 
     def get_actor_flamegraph():
         response = requests.get(
-            f"{webui_url}/worker/cpu_profile?pid={pid}&{get_node_info()}&native={native}"
+            f"{webui_url}/worker/cpu_profile?pid={pid}&{get_node_info()}"
+            f"&native={native}&idle={idle}"
         )
         response.raise_for_status()
         assert response.headers["Content-Type"] == "image/svg+xml", response.headers

--- a/src/ray/protobuf/reporter.proto
+++ b/src/ray/protobuf/reporter.proto
@@ -36,6 +36,8 @@ message CpuProfilingRequest {
   optional uint32 duration = 3;
   // If using native flag for py-spy
   optional bool native = 4;
+  // If using --idle flag for py-spy (include idle threads in the output)
+  optional bool idle = 5;
 }
 
 message CpuProfilingReply {


### PR DESCRIPTION
## Description

Adds an `idle` query parameter to the `/worker/cpu_profile` and `/task/cpu_profile` dashboard endpoints. It's plumbed down to `py-spy record --idle`, which includes stack traces for idle threads in the output. Previously only `--native` was wired through.

Example:

```
/worker/cpu_profile?pid=1334&node_id=...&duration=5&native=0&idle=1
```

## Related issues

None.

## Additional information

**Files touched**

- `src/ray/protobuf/reporter.proto` — adds `optional bool idle = 5` to `CpuProfilingRequest`.
- `python/ray/dashboard/modules/reporter/reporter_head.py` — both `cpu_profile` route handlers read `idle` from the query string and forward it.
- `python/ray/dashboard/modules/reporter/reporter_agent.py` — `CpuProfiling` RPC reads `request.idle` and passes it through.
- `python/ray/dashboard/modules/reporter/profile_manager.py` — `cpu_profile()` accepts `idle: bool = False` and appends `--idle` to the py-spy invocation.
- `python/ray/tests/test_dashboard_profiler.py` — `test_profiler_endpoints` now parametrizes `idle` ∈ {0, 1} on the flamegraph path, mirroring the existing `native` parametrization. No content assertion is added because the busy-loop test actor has no idle threads to verify; the new combinations exercise the wiring (proto field, py-spy flag) and confirm a valid SVG is still returned.
- `ci/lint/pydoclint-baseline.txt` — refreshed (one new entry for the updated `ReportHead.cpu_profile` docstring; two incidental fixes from cleaner type hints / indentation).

**Note for reviewers**

Because `reporter.proto` changed, `python/ray/core/generated/reporter_pb2.py` will be regenerated by the build. Locally, run `/rebuild` (or the equivalent bazel proto target) before exercising the new param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)